### PR TITLE
simd intrinsic not found

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["algorithms", "science"]
 exclude = ["examples/*"]
 
 [dependencies]
-packed_simd = { version = "0.3.4", package = "packed_simd_2" }
+packed_simd = { version = "0.3.9" }
 rayon = "1"
 rand = "0.7"
 num = "0.3"


### PR DESCRIPTION
With the current nightly toolchain, building this crate leads to `error: unrecognized platform-specific intrinsic function: simd_shuffle2`.

This PR fixes this by updating `packed_simd`.