### PR TITLE
upgrade from packed_smid to `core::simd`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["algorithms", "science"]
 exclude = ["examples/*"]
 
 [dependencies]
-packed_simd = "0.3.9"
 rayon = "1.10.0"
 rand = "0.8.5"
 num = "0.4.3"
+num-traits = "0.2.19"
 
 [lib]
 name = "kmeans"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ exclude = ["examples/*"]
 
 [dependencies]
 packed_simd = "0.3.9"
-rayon = "1"
-rand = "0.7"
-num = "0.3"
+rayon = "1.10.0"
+rand = "0.8.5"
+num = "0.4.3"
 
 [lib]
 name = "kmeans"

--- a/examples/lloyd.rs
+++ b/examples/lloyd.rs
@@ -8,7 +8,7 @@ fn main() {
     samples.iter_mut().for_each(|v| *v = rand::random());
 
     // Calculate kmeans, using kmean++ as initialization-method
-    let kmean = KMeans::new(samples, sample_cnt, sample_dims);
+    let kmean: KMeans<f64, 8> = KMeans::new(samples, sample_cnt, sample_dims);
     let result = kmean.kmeans_lloyd(k, max_iter, KMeans::init_kmeanplusplus, &KMeansConfig::default());
 
     println!("Centroids: {:?}", result.centroids);

--- a/examples/minibatch.rs
+++ b/examples/minibatch.rs
@@ -19,7 +19,7 @@ fn main() {
 		.build();
 
     // Calculate kmeans, using kmean++ as initialization-method
-    let kmean = KMeans::new(samples, sample_cnt, sample_dims);
+    let kmean: KMeans<f64, 8> = KMeans::new(samples, sample_cnt, sample_dims);
     let result = kmean.kmeans_minibatch(4, k, max_iter, KMeans::init_random_sample, &conf);
 
     println!("Centroids: {:?}", result.centroids);

--- a/examples/status_events.rs
+++ b/examples/status_events.rs
@@ -9,13 +9,13 @@ fn main() {
 
 	let conf = KMeansConfig::build()
 		.init_done(&|_| println!("Initialization completed."))
-		.iteration_done(&|s, nr, new_distsum|
+		.iteration_done(&|s: &KMeansState<f64>, nr: usize, new_distsum: f64|
 			println!("Iteration {} - Error: {:.2} -> {:.2} | Improvement: {:.2}",
 				nr, s.distsum, new_distsum, s.distsum - new_distsum))
 		.build();
 
     // Calculate kmeans, using kmean++ as initialization-method
-    let kmean = KMeans::new(samples, sample_cnt, sample_dims);
+    let kmean: KMeans<f64, 8> = KMeans::new(samples, sample_cnt, sample_dims);
     let result = kmean.kmeans_minibatch(4, k, max_iter, KMeans::init_random_sample, &conf);
 
     println!("Centroids: {:?}", result.centroids);

--- a/src/api.rs
+++ b/src/api.rs
@@ -394,7 +394,7 @@ mod tests {
         let k = 5;
 
         let mut samples = vec![T::zero();sample_cnt * sample_dims];
-        samples.iter_mut().for_each(|i| *i = thread_rng().gen_range(T::zero(), T::one()));
+        samples.iter_mut().for_each(|i| *i = thread_rng().gen_range(T::zero()..T::one()));
 
         let kmean = KMeans::new(samples, sample_cnt, sample_dims);
         
@@ -446,7 +446,7 @@ mod tests {
         let k = 8;
 
         let mut samples = vec![T::zero();sample_cnt * sample_dims];
-        samples.iter_mut().for_each(|v| *v = thread_rng().gen_range(T::zero(), T::one()));
+        samples.iter_mut().for_each(|v| *v = thread_rng().gen_range(T::zero()..T::one()));
         let kmean = KMeans::new(samples, sample_cnt, sample_dims);
 
         let mut state = KMeansState::new(kmean.sample_cnt, kmean.p_sample_dims, k);

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -15,7 +15,7 @@ macro_rules! assert_approx_eq {
 				if !(delta < tol_val) {
 					panic!(
 						"assertion failed: `(left ≈ right)` \
-						(left: `{:?}`, right: `{:?}`) \
+						(left: `{}`, right: `{}`) \
 						with ∆={:1.1e} (allowed ∆={:e})",
 						left_val , right_val, delta, tol_val
 					)

--- a/src/inits/kmeanplusplus.rs
+++ b/src/inits/kmeanplusplus.rs
@@ -3,25 +3,19 @@ use rand::{
     prelude::*,
     distributions::weighted::WeightedIndex
 };
-use std::iter::Sum;
-use std::ops::{Add, Div, Mul, Sub};
-use std::simd::{num::SimdFloat, LaneCount, Simd, SimdElement, SupportedLaneCount};
+use std::simd::{LaneCount, Simd, SupportedLaneCount};
 use std::ops::DerefMut;
 
-// TODO
-#[inline(always)] pub fn calculate<'a, T, const LANES: usize>(
+#[inline(always)]
+pub fn calculate<'a, T, const LANES: usize>(
     kmean: &KMeans<T, LANES>,
     state: &mut KMeansState<T>,
     config: &KMeansConfig<'a, T>,
 ) where
-    T: SimdElement + Copy + Default + Add<Output = T> + Mul<Output = T> + Div<Output = T> + Sub<Output = T> + Sum + Primitive,
-    Simd<T, LANES>: Sub<Output = Simd<T, LANES>>
-        + Add<Output = Simd<T, LANES>>
-        + Mul<Output = Simd<T, LANES>>
-        + Div<Output = Simd<T, LANES>>
-        + Sum
-        + SimdFloat<Scalar = T>,
-    LaneCount<LANES>: SupportedLaneCount, {
+    T: Primitive,
+    LaneCount<LANES>: SupportedLaneCount,
+    Simd<T, LANES>: SupportedSimdArray<T, LANES>
+{
 	{ // Randomly select first centroid
 		let first_idx = config.rnd.borrow_mut().gen_range(0..kmean.sample_cnt);
 		state.set_centroid_from_iter(0, kmean.p_samples.iter().skip(first_idx * kmean.p_sample_dims).cloned())
@@ -29,7 +23,7 @@ use std::ops::DerefMut;
 	for k in 1..state.k { // For each following centroid...
 		// Calculate distances & update cluster-assignments
 		kmean.update_cluster_assignments(state, Some(k));
-		
+
 		//NOTE: following two calculations are not what Matlab lists on documentation, but what Matlab actually implemented...
 		// Calculate sum of distances per centroid
 		let distsum = state.centroid_distances.iter().cloned().sum();
@@ -58,21 +52,16 @@ mod tests {
     #[bench]
     fn init_kmeanplusplus_f64(b: &mut Bencher) { init_kmeanplusplus::<f64, 8>(b); }
 
-    // TODO
     fn init_kmeanplusplus<T: Primitive, const LANES:usize>(b: &mut Bencher)
 	where
-	T: SimdElement + Copy + Default + Add<Output = T> + Mul<Output = T> + Div<Output = T> + Sub<Output = T> + Sum + Primitive,
-    Simd<T, LANES>: Sub<Output = Simd<T, LANES>>
-        + Add<Output = Simd<T, LANES>>
-        + Mul<Output = Simd<T, LANES>>
-        + Div<Output = Simd<T, LANES>>
-        + Sum
-        + SimdFloat<Scalar = T>,
-	LaneCount<LANES>: SupportedLaneCount {
+        T: Primitive,
+        LaneCount<LANES>: SupportedLaneCount,
+        Simd<T, LANES>: SupportedSimdArray<T, LANES>
+    {
 		let sample_cnt = 20000;
 		let sample_dims = 16;
 		let k = 32;
-		
+
         let mut rnd = rand::rngs::StdRng::seed_from_u64(1337);
         let mut samples = vec![T::zero();sample_cnt * sample_dims];
         samples.iter_mut().for_each(|v| *v = rnd.gen_range(T::zero()..T::one()));

--- a/src/inits/kmeanplusplus.rs
+++ b/src/inits/kmeanplusplus.rs
@@ -3,11 +3,25 @@ use rand::{
     prelude::*,
     distributions::weighted::WeightedIndex
 };
+use std::iter::Sum;
+use std::ops::{Add, Div, Mul, Sub};
+use std::simd::{num::SimdFloat, LaneCount, Simd, SimdElement, SupportedLaneCount};
 use std::ops::DerefMut;
-use packed_simd::{Simd, SimdArray};
 
-#[inline(always)] pub fn calculate<'a, T: Primitive>(kmean: &KMeans<T>, state: &mut KMeansState<T>, config: &KMeansConfig<'a, T>)
-				where T: Primitive, [T;LANES]: SimdArray, Simd<[T;LANES]>: SimdWrapper<T> {
+// TODO
+#[inline(always)] pub fn calculate<'a, T, const LANES: usize>(
+    kmean: &KMeans<T, LANES>,
+    state: &mut KMeansState<T>,
+    config: &KMeansConfig<'a, T>,
+) where
+    T: SimdElement + Copy + Default + Add<Output = T> + Mul<Output = T> + Div<Output = T> + Sub<Output = T> + Sum + Primitive,
+    Simd<T, LANES>: Sub<Output = Simd<T, LANES>>
+        + Add<Output = Simd<T, LANES>>
+        + Mul<Output = Simd<T, LANES>>
+        + Div<Output = Simd<T, LANES>>
+        + Sum
+        + SimdFloat<Scalar = T>,
+    LaneCount<LANES>: SupportedLaneCount, {
 	{ // Randomly select first centroid
 		let first_idx = config.rnd.borrow_mut().gen_range(0..kmean.sample_cnt);
 		state.set_centroid_from_iter(0, kmean.p_samples.iter().skip(first_idx * kmean.p_sample_dims).cloned())
@@ -40,11 +54,21 @@ mod tests {
     use super::*;
 
     #[bench]
-    fn init_kmeanplusplus_f32(b: &mut Bencher) { init_kmeanplusplus::<f32>(b); }
+    fn init_kmeanplusplus_f32(b: &mut Bencher) { init_kmeanplusplus::<f32, 8>(b); }
     #[bench]
-    fn init_kmeanplusplus_f64(b: &mut Bencher) { init_kmeanplusplus::<f64>(b); }
+    fn init_kmeanplusplus_f64(b: &mut Bencher) { init_kmeanplusplus::<f64, 8>(b); }
 
-    fn init_kmeanplusplus<T: Primitive>(b: &mut Bencher) where [T;LANES] : SimdArray, Simd<[T;LANES]>: SimdWrapper<T> {
+    // TODO
+    fn init_kmeanplusplus<T: Primitive, const LANES:usize>(b: &mut Bencher)
+	where
+	T: SimdElement + Copy + Default + Add<Output = T> + Mul<Output = T> + Div<Output = T> + Sub<Output = T> + Sum + Primitive,
+    Simd<T, LANES>: Sub<Output = Simd<T, LANES>>
+        + Add<Output = Simd<T, LANES>>
+        + Mul<Output = Simd<T, LANES>>
+        + Div<Output = Simd<T, LANES>>
+        + Sum
+        + SimdFloat<Scalar = T>,
+	LaneCount<LANES>: SupportedLaneCount {
 		let sample_cnt = 20000;
 		let sample_dims = 16;
 		let k = 32;
@@ -52,8 +76,8 @@ mod tests {
         let mut rnd = rand::rngs::StdRng::seed_from_u64(1337);
         let mut samples = vec![T::zero();sample_cnt * sample_dims];
         samples.iter_mut().for_each(|v| *v = rnd.gen_range(T::zero()..T::one()));
-        let kmean = KMeans::new(samples, sample_cnt, sample_dims);
-        let mut state = KMeansState::new(sample_cnt, kmean.p_sample_dims, k);
+        let kmean: KMeans<_, LANES> = KMeans::new(samples, sample_cnt, sample_dims);
+        let mut state = KMeansState::new::<LANES>(sample_cnt, kmean.p_sample_dims, k);
 		let conf = KMeansConfig::build().random_generator(rnd).build();
 
         b.iter(|| {

--- a/src/inits/kmeanplusplus.rs
+++ b/src/inits/kmeanplusplus.rs
@@ -9,7 +9,7 @@ use packed_simd::{Simd, SimdArray};
 #[inline(always)] pub fn calculate<'a, T: Primitive>(kmean: &KMeans<T>, state: &mut KMeansState<T>, config: &KMeansConfig<'a, T>)
 				where T: Primitive, [T;LANES]: SimdArray, Simd<[T;LANES]>: SimdWrapper<T> {
 	{ // Randomly select first centroid
-		let first_idx = config.rnd.borrow_mut().gen_range(0, kmean.sample_cnt);
+		let first_idx = config.rnd.borrow_mut().gen_range(0..kmean.sample_cnt);
 		state.set_centroid_from_iter(0, kmean.p_samples.iter().skip(first_idx * kmean.p_sample_dims).cloned())
 	}
 	for k in 1..state.k { // For each following centroid...
@@ -51,7 +51,7 @@ mod tests {
 		
         let mut rnd = rand::rngs::StdRng::seed_from_u64(1337);
         let mut samples = vec![T::zero();sample_cnt * sample_dims];
-        samples.iter_mut().for_each(|v| *v = rnd.gen_range(T::zero(), T::one()));
+        samples.iter_mut().for_each(|v| *v = rnd.gen_range(T::zero()..T::one()));
         let kmean = KMeans::new(samples, sample_cnt, sample_dims);
         let mut state = KMeansState::new(sample_cnt, kmean.p_sample_dims, k);
 		let conf = KMeansConfig::build().random_generator(rnd).build();

--- a/src/inits/randompartition.rs
+++ b/src/inits/randompartition.rs
@@ -1,23 +1,16 @@
 use crate::{KMeans, KMeansState, KMeansConfig, memory::*};
 use rand::prelude::*;
-use std::simd::{Simd, SimdElement, LaneCount, SupportedLaneCount, num::SimdFloat};
-use std::iter::Sum;
-use std::ops::{Add, Mul, Div, Sub};
+use std::simd::{Simd, LaneCount, SupportedLaneCount};
 
-// TODO
-#[inline(always)] pub fn calculate<'a, T, const LANES: usize>(
+#[inline(always)]
+pub fn calculate<'a, T, const LANES: usize>(
     kmean: &KMeans<T, LANES>,
     state: &mut KMeansState<T>,
     config: &KMeansConfig<'a, T>,
 ) where
-    T: SimdElement + Copy + Default + Add<Output = T> + Mul<Output = T> + Div<Output = T> + Sub<Output = T> + Sum + Primitive,
-    Simd<T, LANES>: Sub<Output = Simd<T, LANES>>
-        + Add<Output = Simd<T, LANES>>
-        + Mul<Output = Simd<T, LANES>>
-        + Div<Output = Simd<T, LANES>>
-        + Sum
-        + SimdFloat<Scalar = T>,
-    LaneCount<LANES>: SupportedLaneCount,
+	T: Primitive,
+	LaneCount<LANES>: SupportedLaneCount,
+	Simd<T, LANES>: SupportedSimdArray<T, LANES>
 {
 	let (assignments, centroids, centroid_frequency, k) =
 		(&mut state.assignments, &mut state.centroids, &mut state.centroid_frequency, state.k);

--- a/src/inits/randompartition.rs
+++ b/src/inits/randompartition.rs
@@ -1,15 +1,29 @@
 use crate::{KMeans, KMeansState, KMeansConfig, memory::*};
 use rand::prelude::*;
-use packed_simd::{Simd, SimdArray};
+use std::simd::{Simd, SimdElement, LaneCount, SupportedLaneCount, num::SimdFloat};
+use std::iter::Sum;
+use std::ops::{Add, Mul, Div, Sub};
 
-#[inline(always)] pub fn calculate<'a, T: Primitive>(kmean: &KMeans<T>, state: &mut KMeansState<T>, config: &KMeansConfig<'a, T>)
-				where T: Primitive, [T;LANES]: SimdArray, Simd<[T;LANES]>: SimdWrapper<T> {
-
+// TODO
+#[inline(always)] pub fn calculate<'a, T, const LANES: usize>(
+    kmean: &KMeans<T, LANES>,
+    state: &mut KMeansState<T>,
+    config: &KMeansConfig<'a, T>,
+) where
+    T: SimdElement + Copy + Default + Add<Output = T> + Mul<Output = T> + Div<Output = T> + Sub<Output = T> + Sum + Primitive,
+    Simd<T, LANES>: Sub<Output = Simd<T, LANES>>
+        + Add<Output = Simd<T, LANES>>
+        + Mul<Output = Simd<T, LANES>>
+        + Div<Output = Simd<T, LANES>>
+        + Sum
+        + SimdFloat<Scalar = T>,
+    LaneCount<LANES>: SupportedLaneCount,
+{
 	let (assignments, centroids, centroid_frequency, k) =
 		(&mut state.assignments, &mut state.centroids, &mut state.centroid_frequency, state.k);
 
 	assignments.iter_mut().for_each(|a| {
-		*a = config.rnd.borrow_mut().gen_range(0, k);
+        *a = config.rnd.borrow_mut().gen_range(0..k);
 		centroid_frequency[*a] += 1;
 	});
 	kmean.p_samples.chunks_exact(kmean.p_sample_dims)

--- a/src/inits/randomsample.rs
+++ b/src/inits/randomsample.rs
@@ -1,29 +1,14 @@
 use crate::{KMeans, KMeansState, KMeansConfig, memory::*};
 use rand::prelude::*;
-use std::iter::Sum;
-use std::ops::{Add, Div, Mul, Sub};
-use std::simd::{num::SimdFloat, LaneCount, Simd, SimdElement, SupportedLaneCount};
+use std::simd::{LaneCount, Simd, SupportedLaneCount};
 use std::ops::DerefMut;
 
-#[inline(always)] pub fn calculate<'a, T, const LANES: usize>(kmean: &KMeans<T, LANES>, state: &mut KMeansState<T>, config: &KMeansConfig<'a, T>)
-				where
-    T: SimdElement
-        + Copy
-        + Default
-        + Add<Output = T>
-        + Mul<Output = T>
-        + Div<Output = T>
-        + Sub<Output = T>
-        + Sum
-        + Primitive,
-    Simd<T, LANES>: Sub<Output = Simd<T, LANES>>
-        + Add<Output = Simd<T, LANES>>
-        + Sub<Output = Simd<T, LANES>>
-        + Mul<Output = Simd<T, LANES>>
-        + Div<Output = Simd<T, LANES>>
-        + Sum
-        + SimdFloat<Scalar = T>,
+#[inline(always)]
+pub fn calculate<'a, T, const LANES: usize>(kmean: &KMeans<T, LANES>, state: &mut KMeansState<T>, config: &KMeansConfig<'a, T>)
+where
+    T: Primitive,
     LaneCount<LANES>: SupportedLaneCount,
+    Simd<T, LANES>: SupportedSimdArray<T, LANES>
 {
     kmean.p_samples.chunks_exact(kmean.p_sample_dims)
 		.choose_multiple(config.rnd.borrow_mut().deref_mut(), state.k).iter().cloned()

--- a/src/inits/randomsample.rs
+++ b/src/inits/randomsample.rs
@@ -1,11 +1,31 @@
 use crate::{KMeans, KMeansState, KMeansConfig, memory::*};
 use rand::prelude::*;
+use std::iter::Sum;
+use std::ops::{Add, Div, Mul, Sub};
+use std::simd::{num::SimdFloat, LaneCount, Simd, SimdElement, SupportedLaneCount};
 use std::ops::DerefMut;
-use packed_simd::{Simd, SimdArray};
 
-#[inline(always)] pub fn calculate<'a, T: Primitive>(kmean: &KMeans<T>, state: &mut KMeansState<T>, config: &KMeansConfig<'a, T>)
-				where T: Primitive, [T;LANES]: SimdArray, Simd<[T;LANES]>: SimdWrapper<T> {
-	kmean.p_samples.chunks_exact(kmean.p_sample_dims)
+#[inline(always)] pub fn calculate<'a, T, const LANES: usize>(kmean: &KMeans<T, LANES>, state: &mut KMeansState<T>, config: &KMeansConfig<'a, T>)
+				where
+    T: SimdElement
+        + Copy
+        + Default
+        + Add<Output = T>
+        + Mul<Output = T>
+        + Div<Output = T>
+        + Sub<Output = T>
+        + Sum
+        + Primitive,
+    Simd<T, LANES>: Sub<Output = Simd<T, LANES>>
+        + Add<Output = Simd<T, LANES>>
+        + Sub<Output = Simd<T, LANES>>
+        + Mul<Output = Simd<T, LANES>>
+        + Div<Output = Simd<T, LANES>>
+        + Sum
+        + SimdFloat<Scalar = T>,
+    LaneCount<LANES>: SupportedLaneCount,
+{
+    kmean.p_samples.chunks_exact(kmean.p_sample_dims)
 		.choose_multiple(config.rnd.borrow_mut().deref_mut(), state.k).iter().cloned()
 		.enumerate()
 		.for_each(|(ci, c)| { // Copy randomly chosen centroids into state.centroids

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![feature(portable_simd)]
 
 //! # kmeans - API documentation
 //!
@@ -111,39 +112,139 @@ mod tests {
     use test::Bencher;
     use rand::prelude::*;
     use super::*;
-    use crate::memory::*;
-    use packed_simd::{Simd, SimdArray};
+    use std::iter::Sum;
+    use std::ops::{Add, Div, Mul, Sub};
+    use std::simd::{num::SimdFloat, LaneCount, Simd, SimdElement, SupportedLaneCount};
 
-    #[bench] fn complete_benchmark_lloyd_small_f64(b: &mut Bencher) { complete_benchmark_lloyd::<f64>(b, 200, 2000, 10, 32); }
-    #[bench] fn complete_benchmark_lloyd_mid_f64(b: &mut Bencher) { complete_benchmark_lloyd::<f64>(b, 2000, 200, 10, 32); }
-    #[bench] fn complete_benchmark_lloyd_big_f64(b: &mut Bencher) { complete_benchmark_lloyd::<f64>(b, 10000, 8, 10, 32); }
-    #[bench] fn complete_benchmark_lloyd_huge_f64(b: &mut Bencher) { complete_benchmark_lloyd::<f64>(b, 20000, 256, 1, 32); }
-    #[bench] fn complete_benchmark_lloyd_small_f32(b: &mut Bencher) { complete_benchmark_lloyd::<f32>(b, 200, 2000, 10, 32); }
-    #[bench] fn complete_benchmark_lloyd_mid_f32(b: &mut Bencher) { complete_benchmark_lloyd::<f32>(b, 2000, 200, 10, 32); }
-    #[bench] fn complete_benchmark_lloyd_big_f32(b: &mut Bencher) { complete_benchmark_lloyd::<f32>(b, 10000, 8, 10, 32); }
-    #[bench] fn complete_benchmark_lloyd_huge_f32(b: &mut Bencher) { complete_benchmark_lloyd::<f32>(b, 20000, 256, 1, 32); }
-    fn complete_benchmark_lloyd<T: Primitive>(b: &mut Bencher, sample_cnt: usize, sample_dims: usize, max_iter: usize, k: usize)
-                    where [T;LANES] : SimdArray, Simd<[T;LANES]>: SimdWrapper<T> {
+    #[bench]
+    fn complete_benchmark_lloyd_small_f64(b: &mut Bencher) {
+        complete_benchmark_lloyd::<f64, 8>(b, 200, 2000, 10, 32);
+    }
+    #[bench]
+    fn complete_benchmark_lloyd_mid_f64(b: &mut Bencher) {
+        complete_benchmark_lloyd::<f64, 8>(b, 2000, 200, 10, 32);
+    }
+    #[bench]
+    fn complete_benchmark_lloyd_big_f64(b: &mut Bencher) {
+        complete_benchmark_lloyd::<f64, 8>(b, 10000, 8, 10, 32);
+    }
+    #[bench]
+    fn complete_benchmark_lloyd_huge_f64(b: &mut Bencher) {
+        complete_benchmark_lloyd::<f64, 8>(b, 20000, 256, 1, 32);
+    }
+    #[bench]
+    fn complete_benchmark_lloyd_small_f32(b: &mut Bencher) {
+        complete_benchmark_lloyd::<f32, 8>(b, 200, 2000, 10, 32);
+    }
+    #[bench]
+    fn complete_benchmark_lloyd_mid_f32(b: &mut Bencher) {
+        complete_benchmark_lloyd::<f32, 8>(b, 2000, 200, 10, 32);
+    }
+    #[bench]
+    fn complete_benchmark_lloyd_big_f32(b: &mut Bencher) {
+        complete_benchmark_lloyd::<f32, 8>(b, 10000, 8, 10, 32);
+    }
+    #[bench]
+    fn complete_benchmark_lloyd_huge_f32(b: &mut Bencher) {
+        complete_benchmark_lloyd::<f32, 8>(b, 20000, 256, 1, 32);
+    }
+    // TODO
+    fn complete_benchmark_lloyd<T: Primitive, const LANES: usize>(
+        b: &mut Bencher,
+        sample_cnt: usize,
+        sample_dims: usize,
+        max_iter: usize,
+        k: usize,
+    ) where
+        T: SimdElement
+            + Copy
+            + Default
+            + Add<Output = T>
+            + Mul<Output = T>
+            + Div<Output = T>
+            + Sub<Output = T>
+            + Sum
+            + Primitive
+            + num::Zero
+            + num::One,
+        Simd<T, LANES>: Sub<Output = Simd<T, LANES>>
+            + Add<Output = Simd<T, LANES>>
+            + Mul<Output = Simd<T, LANES>>
+            + Div<Output = Simd<T, LANES>>
+            + Sum
+            + SimdFloat<Scalar = T>,
+        LaneCount<LANES>: SupportedLaneCount,
+    {
         let mut rnd = rand::rngs::StdRng::seed_from_u64(1337);
         let mut samples = vec![T::zero();sample_cnt * sample_dims];
         samples.iter_mut().for_each(|v| *v = rnd.gen_range(T::zero()..T::one()));
-        let kmean = KMeans::new(samples, sample_cnt, sample_dims);
+        let kmean: KMeans<T, LANES> = KMeans::new(samples, sample_cnt, sample_dims);
         let conf = KMeansConfig::build().random_generator(rnd).build();
         b.iter(|| {
             kmean.kmeans_lloyd(k, max_iter, KMeans::init_kmeanplusplus, &conf)
         });
     }
 
-    #[bench] fn complete_benchmark_minibatch_small_f64(b: &mut Bencher) { complete_benchmark_minibatch::<f64>(b, 30, 200, 2000, 100, 32); }
-    #[bench] fn complete_benchmark_minibatch_mid_f64(b: &mut Bencher) { complete_benchmark_minibatch::<f64>(b, 200, 2000, 200, 100, 32); }
-    #[bench] fn complete_benchmark_minibatch_big_f64(b: &mut Bencher) { complete_benchmark_minibatch::<f64>(b, 1000, 10000, 8, 100, 32); }
-    #[bench] fn complete_benchmark_minibatch_huge_f64(b: &mut Bencher) { complete_benchmark_minibatch::<f64>(b, 2000, 20000, 256, 30, 32); }
-    #[bench] fn complete_benchmark_minibatch_small_f32(b: &mut Bencher) { complete_benchmark_minibatch::<f32>(b, 30, 200, 2000, 100, 32); }
-    #[bench] fn complete_benchmark_minibatch_mid_f32(b: &mut Bencher) { complete_benchmark_minibatch::<f32>(b, 200, 2000, 200, 100, 32); }
-    #[bench] fn complete_benchmark_minibatch_big_f32(b: &mut Bencher) { complete_benchmark_minibatch::<f32>(b, 1000, 10000, 8, 100, 32); }
-    #[bench] fn complete_benchmark_minibatch_huge_f32(b: &mut Bencher) { complete_benchmark_minibatch::<f32>(b, 2000, 20000, 256, 30, 32); }
-    fn complete_benchmark_minibatch<T: Primitive>(b: &mut Bencher, batch_size: usize, sample_cnt: usize, sample_dims: usize, max_iter: usize, k: usize)
-                    where [T;LANES] : SimdArray, Simd<[T;LANES]>: SimdWrapper<T> {
+    #[bench]
+    fn complete_benchmark_minibatch_small_f64(b: &mut Bencher) {
+        complete_benchmark_minibatch::<f64, 8>(b, 30, 200, 2000, 100, 32);
+    }
+    #[bench]
+    fn complete_benchmark_minibatch_mid_f64(b: &mut Bencher) {
+        complete_benchmark_minibatch::<f64, 8>(b, 200, 2000, 200, 100, 32);
+    }
+    #[bench]
+    fn complete_benchmark_minibatch_big_f64(b: &mut Bencher) {
+        complete_benchmark_minibatch::<f64, 8>(b, 1000, 10000, 8, 100, 32);
+    }
+    #[bench]
+    fn complete_benchmark_minibatch_huge_f64(b: &mut Bencher) {
+        complete_benchmark_minibatch::<f64, 8>(b, 2000, 20000, 256, 30, 32);
+    }
+    #[bench]
+    fn complete_benchmark_minibatch_small_f32(b: &mut Bencher) {
+        complete_benchmark_minibatch::<f32, 8>(b, 30, 200, 2000, 100, 32);
+    }
+    #[bench]
+    fn complete_benchmark_minibatch_mid_f32(b: &mut Bencher) {
+        complete_benchmark_minibatch::<f32, 8>(b, 200, 2000, 200, 100, 32);
+    }
+    #[bench]
+    fn complete_benchmark_minibatch_big_f32(b: &mut Bencher) {
+        complete_benchmark_minibatch::<f32, 8>(b, 1000, 10000, 8, 100, 32);
+    }
+    #[bench]
+    fn complete_benchmark_minibatch_huge_f32(b: &mut Bencher) {
+        complete_benchmark_minibatch::<f32, 8>(b, 2000, 20000, 256, 30, 32);
+    }
+    // TODO
+    fn complete_benchmark_minibatch<T: Primitive, const LANES: usize>(
+        b: &mut Bencher,
+        batch_size: usize,
+        sample_cnt: usize,
+        sample_dims: usize,
+        max_iter: usize,
+        k: usize,
+    ) where
+        T: SimdElement
+            + Copy
+            + Default
+            + Add<Output = T>
+            + Mul<Output = T>
+            + Div<Output = T>
+            + Sub<Output = T>
+            + Sum
+            + Primitive
+            + num::Zero
+            + num::One,
+        Simd<T, LANES>: Sub<Output = Simd<T, LANES>>
+            + Add<Output = Simd<T, LANES>>
+            + Mul<Output = Simd<T, LANES>>
+            + Div<Output = Simd<T, LANES>>
+            + Sum
+            + SimdFloat<Scalar = T>,
+        LaneCount<LANES>: SupportedLaneCount,
+    {
         let mut rnd = rand::rngs::StdRng::seed_from_u64(1337);
         let mut samples = vec![T::zero();sample_cnt * sample_dims];
         samples.iter_mut().for_each(|v| *v = rnd.gen_range(T::zero()..T::one()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ mod tests {
                     where [T;LANES] : SimdArray, Simd<[T;LANES]>: SimdWrapper<T> {
         let mut rnd = rand::rngs::StdRng::seed_from_u64(1337);
         let mut samples = vec![T::zero();sample_cnt * sample_dims];
-        samples.iter_mut().for_each(|v| *v = rnd.gen_range(T::zero(), T::one()));
+        samples.iter_mut().for_each(|v| *v = rnd.gen_range(T::zero()..T::one()));
         let kmean = KMeans::new(samples, sample_cnt, sample_dims);
         let conf = KMeansConfig::build().random_generator(rnd).build();
         b.iter(|| {
@@ -146,7 +146,7 @@ mod tests {
                     where [T;LANES] : SimdArray, Simd<[T;LANES]>: SimdWrapper<T> {
         let mut rnd = rand::rngs::StdRng::seed_from_u64(1337);
         let mut samples = vec![T::zero();sample_cnt * sample_dims];
-        samples.iter_mut().for_each(|v| *v = rnd.gen_range(T::zero(), T::one()));
+        samples.iter_mut().for_each(|v| *v = rnd.gen_range(T::zero()..T::one()));
         let kmean = KMeans::new(samples, sample_cnt, sample_dims);
         let conf = KMeansConfig::build().random_generator(rnd).build();
         b.iter(|| {

--- a/src/variants/lloyd.rs
+++ b/src/variants/lloyd.rs
@@ -1,26 +1,18 @@
 use crate::{KMeans, KMeansState, KMeansConfig, memory::*};
-use std::simd::{Simd, SimdElement, LaneCount, SupportedLaneCount, num::SimdFloat};
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
-use std::iter::Sum;
+use std::simd::{Simd, LaneCount, SupportedLaneCount};
 
-pub(crate) struct Lloyd<T, const LANES: usize> 
-where 
-    T: Primitive, 
+pub(crate) struct Lloyd<T, const LANES: usize>
+where
+    T: Primitive,
     LaneCount<LANES>: SupportedLaneCount,
 {
     _p: std::marker::PhantomData<T>,
 }
-// TODO
 impl<T, const LANES: usize> Lloyd<T, LANES>
 where
-T: SimdElement + Copy + Default + Add<Output = T> + Mul<Output = T> + Div<Output = T> + Sub<Output = T> + Sum + Primitive,
-Simd<T, LANES>: Sub<Output = Simd<T, LANES>>
-    + Add<Output = Simd<T, LANES>>
-    + Mul<Output = Simd<T, LANES>>
-    + Div<Output = Simd<T, LANES>>
-    + Sum
-    + SimdFloat<Scalar = T>,
-LaneCount<LANES>: SupportedLaneCount,
+    T: Primitive,
+    LaneCount<LANES>: SupportedLaneCount,
+    Simd<T, LANES>: SupportedSimdArray<T, LANES>
 {
     fn update_centroids(data: &KMeans<T, LANES>, state: &mut KMeansState<T>) -> T
     {

--- a/src/variants/minibatch.rs
+++ b/src/variants/minibatch.rs
@@ -2,10 +2,8 @@ use crate::{KMeans, KMeansConfig, KMeansState, memory::*};
 use rand::prelude::*;
 use rayon::prelude::*;
 use std::ops::{Range, DerefMut};
-use std::iter::Sum;
-use std::ops::{Add, Sub, Mul, Div};
 use std::simd::num::SimdFloat;
-use std::simd::{LaneCount, Simd, SimdElement, SupportedLaneCount};
+use std::simd::{LaneCount, Simd, SupportedLaneCount};
 
 struct BatchInfo {
 	start_idx: usize,
@@ -20,17 +18,11 @@ impl BatchInfo {
 pub(crate) struct Minibatch<T, const LANES: usize> where T: Primitive, LaneCount<LANES>: SupportedLaneCount{
 	_p: std::marker::PhantomData<T>
 }
-// TODO
 impl<T, const LANES: usize> Minibatch<T, LANES>
 where
-	T: SimdElement + Copy + Default + Add<Output = T> + Mul<Output = T> + Div<Output = T> + Sub<Output = T> + Sum + Primitive,
-	Simd<T, LANES>: Sub<Output = Simd<T, LANES>>
-		+ Add<Output = Simd<T, LANES>>
-		+ Mul<Output = Simd<T, LANES>>
-		+ Div<Output = Simd<T, LANES>>
-		+ Sum
-		+ SimdFloat<Scalar = T>,
+	T: Primitive,
 	LaneCount<LANES>: SupportedLaneCount,
+	Simd<T, LANES>: SupportedSimdArray<T, LANES>
 {
 	fn update_cluster_assignments<'a>(data: &KMeans<T, LANES>, state: &mut KMeansState<T>, batch: &BatchInfo, shuffled_samples: &'a [T], limit_k: Option<usize>) {
 		let centroids = &state.centroids;


### PR DESCRIPTION
1. SMID Fixes
Reason: Rust has integrated some SMID functions into the standard core library, eliminating the need for the platform-intrinsic feature. The previous packed_smid was rendered unusable, so it has been transitioned to be compatible with the core library.
2. Test Case Order Fixes
Addressed issues caused by the order of execution affecting test cases.
3. Dependency Updates
Updated dependencies to their latest versions for enhanced functionality and security.