### PR TITLE
feat: allow custom centroid initialization

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,7 +1,6 @@
 use crate::memory::*;
 use crate::{helpers, AbortStrategy};
-use core::simd::num::SimdFloat;
-use core::simd::{LaneCount, Simd, SupportedLaneCount};
+use core::simd::{LaneCount, Simd, SimdFloat, SupportedLaneCount};
 use rand::prelude::*;
 use rayon::prelude::*;
 use std::cell::RefCell;

--- a/src/api.rs
+++ b/src/api.rs
@@ -395,6 +395,17 @@ where
     pub fn init_random_sample(kmean: &KMeans<T, LANES>, state: &mut KMeansState<T>, config: &KMeansConfig<'_, T>) {
         crate::inits::randomsample::calculate(kmean, state, config);
     }
+
+    /// TODO: Precomputed initialization method
+    ///
+    /// ## Description
+    /// This initialization method requires a precomputed list of k centroids to use as initial
+    /// centroids.
+    pub fn init_precomputed(centroids: Vec<T>) -> impl Fn(&KMeans<T, LANES>, &mut KMeansState<T>, &KMeansConfig<'_, T>) {
+        move |kmean, state, config| {
+            crate::inits::precomputed::calculate(kmean, state, config, centroids.clone());
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -396,11 +396,15 @@ where
         crate::inits::randomsample::calculate(kmean, state, config);
     }
 
-    /// TODO: Precomputed initialization method
+    /// Precomputed centroids initialization method
     ///
     /// ## Description
     /// This initialization method requires a precomputed list of k centroids to use as initial
     /// centroids.
+    ///
+    /// ## Note
+    /// This method must be invoked with a precomputed list of centroids. It then
+    /// returns a closure that can be passed to the [`KMeans`] object.
     pub fn init_precomputed(centroids: Vec<T>) -> impl Fn(&KMeans<T, LANES>, &mut KMeansState<T>, &KMeansConfig<'_, T>) {
         move |kmean, state, config| {
             crate::inits::precomputed::calculate(kmean, state, config, centroids.clone());

--- a/src/inits/mod.rs
+++ b/src/inits/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod kmeanplusplus;
+pub(crate) mod precomputed;
 pub(crate) mod randompartition;
 pub(crate) mod randomsample;

--- a/src/inits/precomputed.rs
+++ b/src/inits/precomputed.rs
@@ -1,0 +1,36 @@
+use crate::memory::*;
+use crate::{KMeans, KMeansConfig, KMeansState};
+use std::simd::{LaneCount, Simd, SupportedLaneCount};
+
+#[inline(always)]
+pub fn calculate<T, const LANES: usize>(
+    kmean: &KMeans<T, LANES>, state: &mut KMeansState<T>, _config: &KMeansConfig<'_, T>, computed: Vec<T>,
+) where
+    T: Primitive,
+    LaneCount<LANES>: SupportedLaneCount,
+    Simd<T, LANES>: SupportedSimdArray<T, LANES>,
+{
+    computed.chunks_exact(kmean.p_sample_dims).enumerate().for_each(|(ci, c)| {
+        if ci > state.k {
+            panic!("Initialized with more centroids than k");
+        }
+        state.set_centroid_from_iter(ci, c.iter().cloned());
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn train_with_precomputed_centroids() {
+        let samples = vec![0.0, 1.0, 10.0, 11.0, 20.0, 21.0];
+        let centroids = vec![0.0, 21.0];
+        let (sample_cnt, sample_dims) = (samples.len(), 1);
+
+        let kmean: KMeans<f32, 8> = KMeans::new(samples, sample_cnt, sample_dims);
+        let result = kmean.kmeans_lloyd(2, 200, KMeans::init_precomputed(centroids), &KMeansConfig::default());
+
+        assert_eq!(result.centroids, vec![5.5, 20.5]);
+    }
+}

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,7 +1,6 @@
 use core::fmt;
 use rand::distributions::uniform::SampleUniform;
-use std::simd::num::SimdFloat;
-use std::simd::{LaneCount, Simd, SimdElement, SupportedLaneCount};
+use std::simd::{LaneCount, Simd, SimdElement, SimdFloat, SupportedLaneCount};
 use std::{iter, ops};
 
 pub trait Primitive:

--- a/src/variants/minibatch.rs
+++ b/src/variants/minibatch.rs
@@ -3,8 +3,7 @@ use crate::{KMeans, KMeansConfig, KMeansState};
 use rand::prelude::*;
 use rayon::prelude::*;
 use std::ops::{DerefMut, Range};
-use std::simd::num::SimdFloat;
-use std::simd::{LaneCount, Simd, SupportedLaneCount};
+use std::simd::{LaneCount, Simd, SimdFloat, SupportedLaneCount};
 
 struct BatchInfo {
     start_idx: usize,


### PR DESCRIPTION
Adding a precomputed-centroids initialization method. One calls it with a flat list of k centroids to use instead of generating new ones.

Example: `kmean.kmeans_lloyd(2, 200, KMeans::init_precomputed(vec![1.0, 2.0]), &KMeansConfig::default());`



Resolve issue #7