### PR TITLE
Pass samples as a reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ fn main() {
 
     // Calculate kmeans, using kmean++ as initialization-method
     // KMeans<_, 8> specifies to use f64 SIMD vectors with 8 lanes (e.g. AVX512)
-    let kmean: KMeans<f64, 8, _> = KMeans::new(samples, sample_cnt, sample_dims, EuclideanDistance);
+    let kmean: KMeans<f64, 8, _> = KMeans::new(&samples, sample_cnt, sample_dims, EuclideanDistance);
     let result = kmean.kmeans_lloyd(k, max_iter, KMeans::init_kmeanplusplus, &KMeansConfig::default());
 
     println!("Centroids: {:?}", result.centroids);

--- a/examples/lloyd.rs
+++ b/examples/lloyd.rs
@@ -9,7 +9,7 @@ fn main() {
 
     // Calculate kmeans, using kmean++ as initialization-method
     // KMeans<_, 8> specifies to use f64 SIMD vectors with 8 lanes (e.g. AVX512)
-    let kmean: KMeans<f64, 8, _> = KMeans::new(samples, sample_cnt, sample_dims, EuclideanDistance);
+    let kmean: KMeans<f64, 8, _> = KMeans::new(&samples, sample_cnt, sample_dims, EuclideanDistance);
     let result = kmean.kmeans_lloyd(k, max_iter, KMeans::init_kmeanplusplus, &KMeansConfig::default());
 
     println!("Centroids: {:?}", result.centroids);

--- a/examples/minibatch.rs
+++ b/examples/minibatch.rs
@@ -20,7 +20,7 @@ fn main() {
 
     // Calculate kmeans, using kmean++ as initialization-method
     // KMeans<_, 8> specifies to use f64 SIMD vectors with 8 lanes (e.g. AVX512)
-    let kmean: KMeans<f64, 8, _> = KMeans::new(samples, sample_cnt, sample_dims, EuclideanDistance);
+    let kmean: KMeans<f64, 8, _> = KMeans::new(&samples, sample_cnt, sample_dims, EuclideanDistance);
     let result = kmean.kmeans_minibatch(4, k, max_iter, KMeans::init_random_sample, &conf);
 
     println!("Centroids: {:?}", result.centroids);

--- a/examples/status_events.rs
+++ b/examples/status_events.rs
@@ -26,7 +26,7 @@ fn main() {
 
     // Calculate kmeans, using kmean++ as initialization-method
     // KMeans<_, 8> specifies to use f64 SIMD vectors with 8 lanes (e.g. AVX512)
-    let kmean: KMeans<f64, 8, _> = KMeans::new(samples, sample_cnt, sample_dims, EuclideanDistance);
+    let kmean: KMeans<f64, 8, _> = KMeans::new(&samples, sample_cnt, sample_dims, EuclideanDistance);
     let result = kmean.kmeans_minibatch(4, k, max_iter, KMeans::init_random_sample, &conf);
 
     println!("Centroids: {:?}", result.centroids);

--- a/src/api.rs
+++ b/src/api.rs
@@ -179,13 +179,13 @@ where
     /// - **sample_cnt**: Amount of samples, contained in the passed **samples** vector
     /// - **sample_dims**: Amount of dimensions each sample from the **sample** vector has
     /// - **distance_fn**: Distance function to use for the calculation
-    pub fn new(samples: Vec<T>, sample_cnt: usize, sample_dims: usize, distance_fn: D) -> Self {
+    pub fn new(samples: &Vec<T>, sample_cnt: usize, sample_dims: usize, distance_fn: D) -> Self {
         assert!(samples.len() == sample_cnt * sample_dims);
 
         Self {
             sample_cnt,
             sample_dims,
-            p_samples: StrideBuffer::from_slice::<LANES>(sample_dims, &samples),
+            p_samples: StrideBuffer::from_slice::<LANES>(sample_dims, samples),
             distance_fn,
         }
     }
@@ -267,7 +267,7 @@ where
     ///
     /// // Calculate kmeans, using kmean++ as initialization-method
     /// // KMeans<_, 8> specifies to use f64 SIMD vectors with 8 lanes (e.g. AVX512)
-    /// let kmean: KMeans<_, 8, _> = KMeans::new(samples, sample_cnt, sample_dims, EuclideanDistance);
+    /// let kmean: KMeans<_, 8, _> = KMeans::new(&samples, sample_cnt, sample_dims, EuclideanDistance);
     /// let result = kmean.kmeans_lloyd(k, max_iter, KMeans::init_kmeanplusplus, &KMeansConfig::default());
     ///
     /// println!("Centroids: {:?}", result.centroids);
@@ -306,7 +306,7 @@ where
     ///
     /// // Calculate kmeans, using kmean++ as initialization-method
     /// // KMeans<_, 8> specifies to use f64 SIMD vectors with 8 lanes (e.g. AVX512)
-    /// let kmean: KMeans<_, 8, _> = KMeans::new(samples, sample_cnt, sample_dims, EuclideanDistance);
+    /// let kmean: KMeans<_, 8, _> = KMeans::new(&samples, sample_cnt, sample_dims, EuclideanDistance);
     /// let result = kmean.kmeans_minibatch(4, k, max_iter, KMeans::init_random_sample, &KMeansConfig::default());
     ///
     /// println!("Centroids: {:?}", result.centroids);
@@ -418,7 +418,7 @@ mod tests {
         let mut rng = rand::rngs::StdRng::seed_from_u64(1337);
         samples.iter_mut().for_each(|i| *i = rng.gen_range(T::zero()..T::one()));
 
-        let kmean = KMeans::new(samples, sample_cnt, sample_dims, EuclideanDistance);
+        let kmean = KMeans::new(&samples, sample_cnt, sample_dims, EuclideanDistance);
 
         let mut state = KMeansState::new::<LANES>(kmean.sample_cnt, sample_dims, k);
         state
@@ -493,7 +493,7 @@ mod tests {
         let mut samples = vec![T::zero(); sample_cnt * sample_dims];
         let mut rng = rand::rngs::StdRng::seed_from_u64(1337);
         samples.iter_mut().for_each(|v| *v = rng.gen_range(T::zero()..T::one()));
-        let kmean: KMeans<T, LANES, _> = KMeans::new(samples, sample_cnt, sample_dims, EuclideanDistance);
+        let kmean: KMeans<T, LANES, _> = KMeans::new(&samples, sample_cnt, sample_dims, EuclideanDistance);
 
         let mut state = KMeansState::new::<LANES>(kmean.sample_cnt, sample_dims, k);
         state

--- a/src/inits/kmeanplusplus.rs
+++ b/src/inits/kmeanplusplus.rs
@@ -74,7 +74,7 @@ mod tests {
         let mut rnd = rand::rngs::StdRng::seed_from_u64(1337);
         let mut samples = vec![T::zero(); sample_cnt * sample_dims];
         samples.iter_mut().for_each(|v| *v = rnd.gen_range(T::zero()..T::one()));
-        let kmean: KMeans<_, LANES, _> = KMeans::new(samples, sample_cnt, sample_dims, EuclideanDistance);
+        let kmean: KMeans<_, LANES, _> = KMeans::new(&samples, sample_cnt, sample_dims, EuclideanDistance);
         let mut state = KMeansState::new::<LANES>(sample_cnt, sample_dims, k);
         let conf = KMeansConfig::build().random_generator(rnd).build();
 

--- a/src/inits/precomputed.rs
+++ b/src/inits/precomputed.rs
@@ -27,7 +27,7 @@ mod tests {
         let centroids = vec![0.0, 10.0, 20.0];
         let (sample_cnt, sample_dims) = (samples.len(), 1);
 
-        let kmean: KMeans<f32, 8, _> = KMeans::new(samples, sample_cnt, sample_dims, EuclideanDistance);
+        let kmean: KMeans<f32, 8, _> = KMeans::new(&samples, sample_cnt, sample_dims, EuclideanDistance);
         let result = kmean.kmeans_lloyd(3, 200, KMeans::init_precomputed(centroids), &KMeansConfig::default());
 
         assert_eq!(result.centroids.to_vec(), vec![0.5, 10.5, 20.5]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //!
 //! // Calculate kmeans, using kmean++ as initialization-method
 //! // KMeans<_, 8> specifies to use f64 SIMD vectors with 8 lanes (e.g. AVX512)
-//! let kmean: KMeans<_, 8, _> = KMeans::new(samples, sample_cnt, sample_dims, EuclideanDistance);
+//! let kmean: KMeans<_, 8, _> = KMeans::new(&samples, sample_cnt, sample_dims, EuclideanDistance);
 //! let result = kmean.kmeans_lloyd(k, max_iter, KMeans::init_kmeanplusplus, &KMeansConfig::default());
 //!
 //! println!("Centroids: {:?}", result.centroids);
@@ -69,7 +69,7 @@
 //!
 //! // Calculate kmeans, using kmean++ as initialization-method
 //! // KMeans<_, 8> specifies to use f64 SIMD vectors with 8 lanes (e.g. AVX512)
-//! let kmean: KMeans<_, 8, _> = KMeans::new(samples, sample_cnt, sample_dims, EuclideanDistance);
+//! let kmean: KMeans<_, 8, _> = KMeans::new(&samples, sample_cnt, sample_dims, EuclideanDistance);
 //! let result = kmean.kmeans_minibatch(4, k, max_iter, KMeans::init_random_sample, &conf);
 //!
 //! println!("Centroids: {:?}", result.centroids);
@@ -144,7 +144,7 @@ mod tests {
         let mut rnd = rand::rngs::StdRng::seed_from_u64(1337);
         let mut samples = vec![T::zero(); sample_cnt * sample_dims];
         samples.iter_mut().for_each(|v| *v = rnd.gen_range(T::zero()..T::one()));
-        let kmean: KMeans<T, LANES, _> = KMeans::new(samples, sample_cnt, sample_dims, EuclideanDistance);
+        let kmean: KMeans<T, LANES, _> = KMeans::new(&samples, sample_cnt, sample_dims, EuclideanDistance);
         let conf = KMeansConfig::build().random_generator(rnd).build();
         b.iter(|| kmean.kmeans_lloyd(k, max_iter, KMeans::init_kmeanplusplus, &conf));
     }
@@ -176,7 +176,7 @@ mod tests {
         let mut rnd = rand::rngs::StdRng::seed_from_u64(1337);
         let mut samples = vec![T::zero(); sample_cnt * sample_dims];
         samples.iter_mut().for_each(|v| *v = rnd.gen_range(T::zero()..T::one()));
-        let kmean = KMeans::new(samples, sample_cnt, sample_dims, EuclideanDistance);
+        let kmean = KMeans::new(&samples, sample_cnt, sample_dims, EuclideanDistance);
         let conf = KMeansConfig::build().random_generator(rnd).build();
         b.iter(|| kmean.kmeans_minibatch(batch_size, k, max_iter, KMeans::init_random_sample, &conf));
     }

--- a/src/variants/lloyd.rs
+++ b/src/variants/lloyd.rs
@@ -178,7 +178,7 @@ mod tests {
             1.8, 4.8, 1.8, 5.4, 2.1, 5.6, 2.4, 5.1, 2.3, 5.1, 1.9, 5.9, 2.3, 5.7, 2.5, 5.2, 2.3, 5.0, 1.9, 5.2, 2.0, 5.4, 2.3, 5.1, 1.8,
         ];
 
-        let kmean: KMeans<f64, 8, _> = KMeans::new(samples, 150, 2, EuclideanDistance);
+        let kmean: KMeans<f64, 8, _> = KMeans::new(&samples, 150, 2, EuclideanDistance);
         let rnd = rand::rngs::StdRng::seed_from_u64(1);
         let conf = KMeansConfig::build().random_generator(rnd).build();
         let res = kmean.kmeans_lloyd(3, 100, KMeans::init_kmeanplusplus, &conf);
@@ -248,7 +248,7 @@ mod tests {
             1.8, 4.8, 1.8, 5.4, 2.1, 5.6, 2.4, 5.1, 2.3, 5.1, 1.9, 5.9, 2.3, 5.7, 2.5, 5.2, 2.3, 5.0, 1.9, 5.2, 2.0, 5.4, 2.3, 5.1, 1.8,
         ];
 
-        let kmean: KMeans<f32, 8, _> = KMeans::new(samples, 150, 2, EuclideanDistance);
+        let kmean: KMeans<f32, 8, _> = KMeans::new(&samples, 150, 2, EuclideanDistance);
         let rnd = rand::rngs::StdRng::seed_from_u64(1);
         let conf = KMeansConfig::build().random_generator(rnd).build();
         let res = kmean.kmeans_lloyd(3, 100, KMeans::init_kmeanplusplus, &conf);
@@ -292,7 +292,7 @@ mod tests {
         let samples = vec![1.0, 0.0, 2.0, 0.0, 3.0, 0.0];
         let initial_centroids = [2.0, 0.0, 1337.0, 0.0];
 
-        let kmean = KMeans::new(samples, 3, 2, EuclideanDistance);
+        let kmean = KMeans::new(&samples, 3, 2, EuclideanDistance);
         let rnd = rand::rngs::StdRng::seed_from_u64(1);
         let conf = KMeansConfig::build().random_generator(rnd).build();
 

--- a/src/variants/minibatch.rs
+++ b/src/variants/minibatch.rs
@@ -202,7 +202,7 @@ mod tests {
             1.8, 4.8, 1.8, 5.4, 2.1, 5.6, 2.4, 5.1, 2.3, 5.1, 1.9, 5.9, 2.3, 5.7, 2.5, 5.2, 2.3, 5.0, 1.9, 5.2, 2.0, 5.4, 2.3, 5.1, 1.8,
         ];
 
-        let kmean: KMeans<f64, 8, _> = KMeans::new(samples, 150, 2, EuclideanDistance);
+        let kmean: KMeans<f64, 8, _> = KMeans::new(&samples, 150, 2, EuclideanDistance);
         let rnd = rand::rngs::StdRng::seed_from_u64(3);
         let conf = KMeansConfig::build()
             .random_generator(rnd)
@@ -280,7 +280,7 @@ mod tests {
             1.8, 4.8, 1.8, 5.4, 2.1, 5.6, 2.4, 5.1, 2.3, 5.1, 1.9, 5.9, 2.3, 5.7, 2.5, 5.2, 2.3, 5.0, 1.9, 5.2, 2.0, 5.4, 2.3, 5.1, 1.8,
         ];
 
-        let kmean: KMeans<f32, 8, _> = KMeans::new(samples, 150, 2, EuclideanDistance);
+        let kmean: KMeans<f32, 8, _> = KMeans::new(&samples, 150, 2, EuclideanDistance);
         let rnd = rand::rngs::StdRng::seed_from_u64(3);
         let conf = KMeansConfig::build()
             .random_generator(rnd)


### PR DESCRIPTION
Constructs `KMeans` with `samples` of type `&Vec<T>` rather than of type `Vec<T>`. Minimizes excessive allocations when used repeatedly.